### PR TITLE
Allow for yarn to be used when available to install package globally

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -54,7 +54,7 @@ npm whoami > /dev/null
 if command -v yarn &> /dev/null
 then
   echo "Running with yarn"
-  mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+  mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
   yarn config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
   export PATH="$PATH:`yarn global bin`"
   # Install package we need.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -49,9 +49,22 @@ node --version
 # Check to see if we're logged in
 npm whoami > /dev/null
 
-mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
-npm config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
-export PATH="${HOME}/${BUILDKITE_AGENT_ID}/.npm-global/bin:$PATH"
+# yarn vs NPM
 
-# Install package we need.
-npm install --global "${PACKAGE}"
+if command -v yarn &> /dev/null
+then
+  echo "Running with yarn"
+  mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+  yarn config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
+  export PATH="$PATH:`yarn global bin`"
+  # Install package we need.
+  yarn global add "${PACKAGE}"
+else
+  echo "Running with npm"
+  mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+  npm config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+  export PATH="${HOME}/${BUILDKITE_AGENT_ID}/.npm-global/bin:$PATH"
+
+  # Install package we need.
+  npm install --global "${PACKAGE}"
+fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -53,7 +53,8 @@ npm whoami > /dev/null
 
 if command -v yarn &> /dev/null
 then
-  echo "Running with yarn"
+  echo "Running with yarn. Removing any cached yarn config"
+  rm -rf "${HOME}/.yarnrc" "${HOME}/.yarnrc.yml"
   mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
   yarn config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
   export PATH="$PATH:`yarn global bin`"


### PR DESCRIPTION
Motivated by the lack of `rimraf` when using npm (unknown what happened there). Tested internally with a team and it seems to work OK