### PR TITLE
support yarn v4

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -49,23 +49,31 @@ node --version
 # Check to see if we're logged in
 npm whoami > /dev/null
 
-# yarn vs NPM
+# Install global package
 
-if command -v yarn &> /dev/null
-then
-  echo "Running with yarn. Removing any cached yarn config"
-  rm -rf "${HOME}/.yarnrc" "${HOME}/.yarnrc.yml"
-  mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
-  yarn config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
-  export PATH="$PATH:`yarn global bin`"
-  # Install package we need.
-  yarn global add "${PACKAGE}"
+if command -v yarn &> /dev/null; then
+  yarn_major=$(yarn --version | cut -d. -f1)
+
+  if [[ "$yarn_major" -ge 2 ]]; then
+    echo "Running with yarn ${yarn_major}.x (modern). Using npm for global install."
+    # Yarn 2+ has no 'yarn global add'. Use npm for global package installs.
+    # Do NOT remove ~/.yarnrc.yml - it may contain auth config needed by the pipeline.
+    mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+    npm config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
+    export PATH="${HOME}/${BUILDKITE_AGENT_ID}/.npm-global/bin:$PATH"
+    npm install --global "${PACKAGE}"
+  else
+    echo "Running with yarn classic."
+    rm -rf "${HOME}/.yarnrc"
+    mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
+    yarn config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.config/yarn/global"
+    export PATH="$PATH:$(yarn global bin)"
+    yarn global add "${PACKAGE}"
+  fi
 else
   echo "Running with npm"
   mkdir -p "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
   npm config set prefix "${HOME}/${BUILDKITE_AGENT_ID}/.npm-global"
   export PATH="${HOME}/${BUILDKITE_AGENT_ID}/.npm-global/bin:$PATH"
-
-  # Install package we need.
   npm install --global "${PACKAGE}"
 fi


### PR DESCRIPTION
yarn v4 does not support `yarn config set prefix`, so if we detect a version >= yarn v2 , do thing similarly to npm